### PR TITLE
Fix issue with mysql parser

### DIFF
--- a/lib/graphql/analyzer/parser/mysql.rb
+++ b/lib/graphql/analyzer/parser/mysql.rb
@@ -5,15 +5,25 @@ module GraphQL
         private
 
         def parse
-          root, keys, *values, _ = explain_output.split("\n").reject { |line| line =~ /^\+.*\+$/ }
-          fields = keys[1..-1].split('|').map(&:strip).map(&:downcase)
+          explained_output_by_query = explain_output.split(/^EXPLAIN.*$/).map(&:chomp).reject(&:empty?)
+          queries = explain_output.split("\n").select { |l| l =~ /^EXPLAIN.*$/ }
+          
+          results = []
+          queries.each.with_index do |query, i|
+            keys, *values, _ = explained_output_by_query[i]
+              .split("\n")
+              .map(&:chomp)
+              .reject { |line| line.empty? || line =~ /^\+.*\+$/ }
+            fields = keys[1..-1].split('|').map(&:strip).map(&:downcase)
 
-          explained_queries = values.map do |value|
-            parsed_value = value[1..-1].split("|").map(&:strip)
-            fields.zip(parsed_value).to_h
+            explained_queries = values.map do |value|
+              parsed_value = value[1..-1].split("|").map(&:strip)
+              fields.zip(parsed_value).to_h
+            end
+
+            results << Result.new(query, explained_queries)
           end
-
-          Result.new(root, explained_queries)
+          results
         end
       end
     end

--- a/lib/graphql/analyzer/parser/postgresql.rb
+++ b/lib/graphql/analyzer/parser/postgresql.rb
@@ -6,7 +6,7 @@ module GraphQL
 
         def parse
           root, *values, _ = explain_output.split("\n").reject { |line| line =~ /(QUERY\ PLAN)|-{5,}/ }
-          Result.new(root, [values.join("\n")])
+          [Result.new(root, [values.join("\n")])]
         end
       end
     end

--- a/lib/graphql/analyzer/parser/sqlite3.rb
+++ b/lib/graphql/analyzer/parser/sqlite3.rb
@@ -9,7 +9,7 @@ module GraphQL
         def parse
           root, *values = explain_output.split("\n")
           explained_queries = values.map { |value| FIELDS.zip(value.split("|").map(&:strip)).to_h }
-          Result.new(root, explained_queries)
+          [Result.new(root, explained_queries)]
         end
       end
     end

--- a/spec/graphql/analyzer/instrumentation/mysql_spec.rb
+++ b/spec/graphql/analyzer/instrumentation/mysql_spec.rb
@@ -22,7 +22,7 @@ describe GraphQL::Analyzer::Instrumentation::Mysql do
   context '#instrument' do
     it 'should have explained the query' do
       instrumented_proc.call(nil, nil, mock_ctx)
-      results = mock_ctx.dig('graphql-analyzer', 'resolvers', 0, 'details')
+      results = mock_ctx.dig('graphql-analyzer', 'resolvers', 0, 'details', 0)
       explained_query = results.explained_queries.first
 
       expect(explained_query['select_type']).to eq 'SIMPLE'
@@ -31,7 +31,7 @@ describe GraphQL::Analyzer::Instrumentation::Mysql do
 
     it 'should have captured the query made' do
       instrumented_proc.call(nil, nil, mock_ctx)
-      results = mock_ctx.dig('graphql-analyzer', 'resolvers', 0, 'details')
+      results = mock_ctx.dig('graphql-analyzer', 'resolvers', 0, 'details', 0)
 
       expect(results.root).to match /SELECT.*FROM.*users/
     end

--- a/spec/graphql/analyzer/instrumentation/postgresql_spec.rb
+++ b/spec/graphql/analyzer/instrumentation/postgresql_spec.rb
@@ -22,7 +22,7 @@ describe GraphQL::Analyzer::Instrumentation::Postgresql do
   context '#instrument' do
     it 'should have explained the query' do
       instrumented_proc.call(nil, nil, mock_ctx)
-      results = mock_ctx.dig('graphql-analyzer', 'resolvers', 0, 'details')
+      results = mock_ctx.dig('graphql-analyzer', 'resolvers', 0, 'details', 0)
       explained_query = results.explained_queries.first
 
       expect(explained_query).to match 'Index Scan using users_pkey on users'
@@ -30,7 +30,7 @@ describe GraphQL::Analyzer::Instrumentation::Postgresql do
 
     it 'should have captured the query made' do
       instrumented_proc.call(nil, nil, mock_ctx)
-      results = mock_ctx.dig('graphql-analyzer', 'resolvers', 0, 'details')
+      results = mock_ctx.dig('graphql-analyzer', 'resolvers', 0, 'details', 0)
 
       expect(results.root).to match /SELECT.*FROM.*users/
     end

--- a/spec/graphql/analyzer/instrumentation/sqlite3_spec.rb
+++ b/spec/graphql/analyzer/instrumentation/sqlite3_spec.rb
@@ -22,7 +22,7 @@ describe GraphQL::Analyzer::Instrumentation::Sqlite3 do
   context '#instrument' do
     it 'should have explained the query' do
       instrumented_proc.call(nil, nil, mock_ctx)
-      results = mock_ctx.dig('graphql-analyzer', 'resolvers', 0, 'details')
+      results = mock_ctx.dig('graphql-analyzer', 'resolvers', 0, 'details', 0)
       explained_query = results.explained_queries.first
 
       expect(explained_query['details']).to eq 'SCAN TABLE users'
@@ -30,7 +30,7 @@ describe GraphQL::Analyzer::Instrumentation::Sqlite3 do
 
     it 'should have captured the query made' do
       instrumented_proc.call(nil, nil, mock_ctx)
-      results = mock_ctx.dig('graphql-analyzer', 'resolvers', 0, 'details')
+      results = mock_ctx.dig('graphql-analyzer', 'resolvers', 0, 'details', 0)
 
       expect(results.root).to match /SELECT.*FROM.*users/
     end

--- a/spec/graphql/analyzer/parser/active_record_spec.rb
+++ b/spec/graphql/analyzer/parser/active_record_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 shared_examples 'a parser' do
   it 'produces an explainer result' do
     explain_output = Post.where(author_id: 1).explain
-    expect(parser.parse(explain_output)).to be_kind_of GraphQL::Analyzer::Result
+    expect(parser.parse(explain_output).first).to be_kind_of GraphQL::Analyzer::Result
   end
 end
 


### PR DESCRIPTION
Parsing a mysql query would fail if a resolver made more than one query. This fix allows it to parse an arbitrary number.