### PR TITLE
ElasticSearch instrumentation

### DIFF
--- a/graphql-analyzer.gemspec
+++ b/graphql-analyzer.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "factory_bot"
   spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "activerecord"
+  spec.add_development_dependency "activesupport"
   spec.add_development_dependency "mysql2"
   spec.add_development_dependency "sqlite3"
   spec.add_development_dependency "pg", "~> 0.18"

--- a/lib/graphql/analyzer.rb
+++ b/lib/graphql/analyzer.rb
@@ -1,6 +1,7 @@
 require "graphql"
 require "graphql/analyzer/version"
 require "graphql/analyzer/instrumentation/base"
+require "graphql/analyzer/instrumentation/elastic_search"
 require "graphql/analyzer/instrumentation/mysql"
 require "graphql/analyzer/instrumentation/postgresql"
 require "graphql/analyzer/instrumentation/sqlite3"

--- a/lib/graphql/analyzer/instrumentation/elastic_search.rb
+++ b/lib/graphql/analyzer/instrumentation/elastic_search.rb
@@ -1,0 +1,43 @@
+module GraphQL
+  class Analyzer
+    module Instrumentation
+      class ElasticSearch
+        def initialize
+          @notifications = []
+          ActiveSupport::Notifications.subscribe('search.elasticsearch') do |name, start, finish, id, payload|
+            @notifications << {
+              name: name,
+              start: start,
+              finish: finish,
+              id: id,
+              payload: payload
+            }
+          end
+        end
+
+        def instrument(type, field)
+          ->(obj, args, ctx) do
+            result = field.resolve_proc.call(obj, args, ctx)
+
+            if @notifications.any?
+              # TODO: Merge results when a field makes two types of queries
+              # e.g. path: ['user', 'name'] makes a SQL and ES Query.
+              ctx['graphql-analyzer']['resolvers'] << {
+                'path' => ctx.path,
+                'adapter' => 'elasticsearch',
+                'parentType' => type.name,
+                'fieldName' => field.name,
+                'returnType' => field.type.to_s,
+                'details' => @notifications
+              }
+
+              @notifications = []
+            end
+
+            result
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adding instrumentation to enable analyzing elastic search queries.

```json
{
            "path": [
              "s1"
            ],
            "adapter": "elasticsearch",
            "parentType": "Query",
            "fieldName": "search",
            "returnType": "[SearchResultType!]",
            "details": [
              {
                "name": "search.elasticsearch",
                "start": "2018-03-13T22:00:28.741-04:00",
                "finish": "2018-03-13T22:00:28.751-04:00",
                "id": "030a3d2c8dfb36b671d2",
                "payload": {
                  "name": "Search",
                  "klass": "#<Elasticsearch::Model::Multimodel:0x007fb0e203f3a0>",
                  "search": {
                    "index": [
                      "posts",
                      "comments"
                    ],
                    "type": [
                      "post",
                      "comment"
                    ],
                    "q": "Televizzle"
                  }
                }
              }
            ]
          }
}
```